### PR TITLE
Miscellaneous fixes

### DIFF
--- a/ssssort.h
+++ b/ssssort.h
@@ -34,6 +34,7 @@
 #include <cassert>
 #include <cmath>
 #include <cstring>
+#include <ctime>
 #include <iterator>
 #include <memory>
 #include <random>
@@ -71,7 +72,11 @@ using bucket_t = uint32_t;
 // simplicity.  You can swap this out for std::minstd_rand if the Mersenne
 // Twister is too slow on your hardware.  It's only minimally slower on mine
 // (Haswell i7-4790T).
+#ifdef __MINGW32__
+static std::mt19937 gen(std::time(nullptr));
+#else
 static std::mt19937 gen{std::random_device{}()};
+#endif
 
 // Provides different sampling strategies to choose splitters
 template <typename Iterator, typename value_type>

--- a/ssssort.h
+++ b/ssssort.h
@@ -273,7 +273,7 @@ struct Classifier {
 // Factor to multiply number of buckets by to obtain the number of samples drawn
 inline std::size_t oversampling_factor(std::size_t n) {
     double r = std::sqrt(double(n)/(2*numBuckets*(logBuckets+4)));
-    return std::max(static_cast<std::size_t>(r), 1UL);
+    return std::max<std::size_t>(r, 1);
 }
 
 


### PR DESCRIPTION
Here are a few C++14-compatible fixes to improve the overall quality of the code:

* Replace raw `new` and `delete` by `std::unique_ptr` and `std::make_unique` to avoid memory leaks. I still used `reset(nullptr)` to release memory early when possibe.
* Properly qualify `std::size_t` and `std::uint32_t`, and include the relevant headers `<cstddef>` and `<cstdint>`. It could have caused problems on some platforms.
* Fix a bug on some patforms with `std::max` when `std::size_t` and `unsigned long` are not the same type.
* Initialize the Mersenne twister with `std::time(nullptr)` on MinGW since `std::random_device` does not produce random numbers on MinGW and uses a deterministic sequence instead.

I might make a few more contributions to improve the algorithm even more and make it more generic when I have time :)